### PR TITLE
Error during detection if value of BP_NATIVE_IMAGE is not parseable

### DIFF
--- a/native/detect.go
+++ b/native/detect.go
@@ -88,7 +88,7 @@ func (d Detect) Detect(context libcnb.DetectContext) (libcnb.DetectResult, error
 		return libcnb.DetectResult{}, nil
 	} else if !ok {
 		// still participates if a downstream buildpack requires native-image-applications
-		return result, nil
+		return result, err
 	}
 
 	for i := range result.Plans {


### PR DESCRIPTION
Print an error during detection if `BP_NATIVE_IMAGE` is not one of `1`, `t`, `T`, `TRUE`, `true`, `True`, `0`, `f`, `F`, `FALSE`, `false`, or `False`
