### PR TITLE
Spring should not be required when using Native Image buildpack

### DIFF
--- a/native/build.go
+++ b/native/build.go
@@ -45,16 +45,11 @@ func (b Build) Build(context libcnb.BuildContext) (libcnb.BuildResult, error) {
 		return libcnb.BuildResult{}, fmt.Errorf("unable to read manifest in %s\n%w", context.Application.Path, err)
 	}
 
-	_, ok := manifest.Get("Spring-Boot-Version")
-	if !ok {
-		return libcnb.BuildResult{}, nil
-	}
-
 	cr, err := libpak.NewConfigurationResolver(context.Buildpack, &b.Logger)
 	if err != nil {
 		return libcnb.BuildResult{}, fmt.Errorf("unable to create configuration resolver\n%w", err)
 	}
-	if _, ok = cr.Resolve(DeprecatedConfigNativeImage); ok {
+	if _, ok := cr.Resolve(DeprecatedConfigNativeImage); ok {
 		b.warn(fmt.Sprintf("$%s has been deprecated. Please use $%s instead.",
 			DeprecatedConfigNativeImage,
 			ConfigNativeImage,

--- a/native/native_image.go
+++ b/native/native_image.go
@@ -22,7 +22,6 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
-	"regexp"
 	"strings"
 
 	"github.com/buildpacks/libcnb"
@@ -163,17 +162,4 @@ func (n NativeImage) Contribute(layer libcnb.Layer) (libcnb.Layer, error) {
 
 func (NativeImage) Name() string {
 	return "native-image"
-}
-
-func (NativeImage) hasSpringNative(libs []string) bool {
-	// matches either spring-native or legacy spring-graalvm-native
-	re := regexp.MustCompile(`spring-(?:graalvm-|)native-.+\.jar`)
-
-	for _, l := range libs {
-		if re.MatchString(l) {
-			return true
-		}
-	}
-
-	return false
 }


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary

Presently there is a guard which requires Spring Boot when using the Native Image buildpack. This shouldn't be required.

## Use Cases

Resolves #66 

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [x] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [x] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
