### PR TITLE
Implements Paketo Utilities RFC 0001 to add compression support for native image executables

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,11 @@
 # `gcr.io/paketo-buildpacks/native-image`
+
 The Paketo Native Image Buildpack is a Cloud Native Buildpack that uses the [GraalVM Native Image builder][native-image] (`native-image`) to compile a standalone executable from an executable JAR.
 
 Most users should not use this component buildpack directly and should instead use the [Paketo Java Native Image][bp/java-native-image], which provides the full set of buildpacks required to build a native image application.
 
 ## Behavior
+
 This buildpack will participate if one the following conditions are met:
 
 * `$BP_NATIVE_IMAGE` is set.
@@ -12,13 +14,22 @@ This buildpack will participate if one the following conditions are met:
 The buildpack will do the following:
 
 * Requests that the Native Image builder be installed by requiring `native-image-builder` in the build plan.
+* If `$BP_BINARY_COMPRESSION_METHOD` is set to `upx`, requests that UPX be installed by requiring `upx` in the buildplan.
 * Uses `native-image` a to build a GraalVM native image and removes existing bytecode.
+* Uses `$BP_BINARY_COMPRESSION_METHOD` if set to `upx` or `gzexe` to compress the native image.
 
 ## Configuration
-| Environment Variable | Description
-| -------------------- | -----------
-| `$BP_NATIVE_IMAGE` | Whether to build a native image from the application.  Defaults to false.
-| `$BP_NATIVE_IMAGE_BUILD_ARGUMENTS` | Arguments to pass to the `native-image` command.
+| Environment Variable               | Description                                                                                   |
+| ---------------------------------- | --------------------------------------------------------------------------------------------- |
+| `$BP_NATIVE_IMAGE`                 | Whether to build a native image from the application.  Defaults to false.                     |
+| `$BP_NATIVE_IMAGE_BUILD_ARGUMENTS` | Arguments to pass to the `native-image` command.                                              |
+| `$BP_BINARY_COMPRESSION_METHOD`    | Compression mechanism used to reduce binary size. Options: `none` (default), `upx` or `gzexe` |
+
+### Compression Caveats
+
+1. Using `gzexe` if you intend to run your application on the Paketo Tiny image is not currently supported. The `gzexe` utility will compress your executable into what is a shell script, which executes and extracts the actual binary to a temp location. This process requires `/bin/sh` and that is not in the Tiny image. If you try using `gzexe` with the Tiny stack, it'll build OK but fail to run saying a file is missing.
+
+2. Using `upx` will create a compressed executable that fails to run on M1 Macs. There is at the time of writing a bug in the emulation layer used by Docker on M1 Macs that is triggered when you try to run amd64 executable that has been compressed using `upx`. This is a known issue and will hopefully be patched in a future release.
 
 ## License
 This buildpack is released under version 2.0 of the [Apache License][a].

--- a/native/detect_test.go
+++ b/native/detect_test.go
@@ -200,6 +200,246 @@ func testDetect(t *testing.T, context spec.G, it spec.S) {
 		})
 	})
 
+	context("$BP_BINARY_COMPRESSION_METHOD", func() {
+		it.Before(func() {
+			Expect(os.Setenv("BP_NATIVE_IMAGE", "true")).To(Succeed())
+		})
+
+		it.After(func() {
+			Expect(os.Unsetenv("BP_NATIVE_IMAGE")).To(Succeed())
+		})
+
+		context("upx", func() {
+			it.Before(func() {
+				Expect(os.Setenv("BP_BINARY_COMPRESSION_METHOD", "upx")).To(Succeed())
+			})
+
+			it.After(func() {
+				Expect(os.Unsetenv("BP_BINARY_COMPRESSION_METHOD")).To(Succeed())
+			})
+
+			it("requires upx", func() {
+				Expect(detect.Detect(ctx)).To(Equal(libcnb.DetectResult{
+					Pass: true,
+					Plans: []libcnb.BuildPlan{
+						{
+							Provides: []libcnb.BuildPlanProvide{
+								{Name: "native-image-application"},
+							},
+							Requires: []libcnb.BuildPlanRequire{
+								{
+									Name: "native-image-builder",
+								},
+								{
+									Name:     "jvm-application",
+									Metadata: map[string]interface{}{"native-image": true},
+								},
+								{
+									Name:     "spring-boot",
+									Metadata: map[string]interface{}{"native-image": true},
+								},
+								{
+									Name: "native-image-application",
+								},
+								{
+									Name: "upx",
+								},
+							},
+						},
+						{
+							Provides: []libcnb.BuildPlanProvide{
+								{Name: "native-image-application"},
+							},
+							Requires: []libcnb.BuildPlanRequire{
+								{
+									Name: "native-image-builder",
+								},
+								{
+									Name:     "jvm-application",
+									Metadata: map[string]interface{}{"native-image": true},
+								},
+								{
+									Name: "native-image-application",
+								},
+								{
+									Name: "upx",
+								},
+							},
+						},
+					},
+				}))
+			})
+		})
+
+		context("gzexe", func() {
+			it.Before(func() {
+				Expect(os.Setenv("BP_BINARY_COMPRESSION_METHOD", "gzexe")).To(Succeed())
+			})
+
+			it.After(func() {
+				Expect(os.Unsetenv("BP_BINARY_COMPRESSION_METHOD")).To(Succeed())
+			})
+
+			it("no additional provides or requires", func() {
+				Expect(detect.Detect(ctx)).To(Equal(libcnb.DetectResult{
+					Pass: true,
+					Plans: []libcnb.BuildPlan{
+						{
+							Provides: []libcnb.BuildPlanProvide{
+								{Name: "native-image-application"},
+							},
+							Requires: []libcnb.BuildPlanRequire{
+								{
+									Name: "native-image-builder",
+								},
+								{
+									Name:     "jvm-application",
+									Metadata: map[string]interface{}{"native-image": true},
+								},
+								{
+									Name:     "spring-boot",
+									Metadata: map[string]interface{}{"native-image": true},
+								},
+								{
+									Name: "native-image-application",
+								},
+							},
+						},
+						{
+							Provides: []libcnb.BuildPlanProvide{
+								{Name: "native-image-application"},
+							},
+							Requires: []libcnb.BuildPlanRequire{
+								{
+									Name: "native-image-builder",
+								},
+								{
+									Name:     "jvm-application",
+									Metadata: map[string]interface{}{"native-image": true},
+								},
+								{
+									Name: "native-image-application",
+								},
+							},
+						},
+					},
+				}))
+			})
+		})
+
+		context("none", func() {
+			it.Before(func() {
+				Expect(os.Setenv("BP_BINARY_COMPRESSION_METHOD", "none")).To(Succeed())
+			})
+
+			it.After(func() {
+				Expect(os.Unsetenv("BP_BINARY_COMPRESSION_METHOD")).To(Succeed())
+			})
+
+			it("no additional provides or requires", func() {
+				Expect(detect.Detect(ctx)).To(Equal(libcnb.DetectResult{
+					Pass: true,
+					Plans: []libcnb.BuildPlan{
+						{
+							Provides: []libcnb.BuildPlanProvide{
+								{Name: "native-image-application"},
+							},
+							Requires: []libcnb.BuildPlanRequire{
+								{
+									Name: "native-image-builder",
+								},
+								{
+									Name:     "jvm-application",
+									Metadata: map[string]interface{}{"native-image": true},
+								},
+								{
+									Name:     "spring-boot",
+									Metadata: map[string]interface{}{"native-image": true},
+								},
+								{
+									Name: "native-image-application",
+								},
+							},
+						},
+						{
+							Provides: []libcnb.BuildPlanProvide{
+								{Name: "native-image-application"},
+							},
+							Requires: []libcnb.BuildPlanRequire{
+								{
+									Name: "native-image-builder",
+								},
+								{
+									Name:     "jvm-application",
+									Metadata: map[string]interface{}{"native-image": true},
+								},
+								{
+									Name: "native-image-application",
+								},
+							},
+						},
+					},
+				}))
+			})
+		})
+
+		context("not a supported method", func() {
+			it.Before(func() {
+				Expect(os.Setenv("BP_BINARY_COMPRESSION_METHOD", "foo")).To(Succeed())
+			})
+
+			it.After(func() {
+				Expect(os.Unsetenv("BP_BINARY_COMPRESSION_METHOD")).To(Succeed())
+			})
+
+			it("ignore and no additional provides or requires", func() {
+				Expect(detect.Detect(ctx)).To(Equal(libcnb.DetectResult{
+					Pass: true,
+					Plans: []libcnb.BuildPlan{
+						{
+							Provides: []libcnb.BuildPlanProvide{
+								{Name: "native-image-application"},
+							},
+							Requires: []libcnb.BuildPlanRequire{
+								{
+									Name: "native-image-builder",
+								},
+								{
+									Name:     "jvm-application",
+									Metadata: map[string]interface{}{"native-image": true},
+								},
+								{
+									Name:     "spring-boot",
+									Metadata: map[string]interface{}{"native-image": true},
+								},
+								{
+									Name: "native-image-application",
+								},
+							},
+						},
+						{
+							Provides: []libcnb.BuildPlanProvide{
+								{Name: "native-image-application"},
+							},
+							Requires: []libcnb.BuildPlanRequire{
+								{
+									Name: "native-image-builder",
+								},
+								{
+									Name:     "jvm-application",
+									Metadata: map[string]interface{}{"native-image": true},
+								},
+								{
+									Name: "native-image-application",
+								},
+							},
+						},
+					},
+				}))
+			})
+		})
+	})
+
 	context("$BP_BOOT_NATIVE_IMAGE", func() {
 		it.Before(func() {
 			Expect(os.Setenv("BP_BOOT_NATIVE_IMAGE", "true")).To(Succeed())


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->

Native image executables are large in size. They can benefit a lot from being compressed, 60-80% size reduction.

## Use Cases
<!-- An explanation of the use cases your change enables -->

This PR adds support for using `upx` and `gzexe` to compress images.

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [x] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [x] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
