### PR TITLE
Do not require Start-Class in MANIFEST.MF

### DIFF
--- a/native/native_image.go
+++ b/native/native_image.go
@@ -62,9 +62,9 @@ func NewNativeImage(applicationPath string, arguments string, compressor string,
 }
 
 func (n NativeImage) Contribute(layer libcnb.Layer) (libcnb.Layer, error) {
-	startClass, ok := n.Manifest.Get("Start-Class")
-	if !ok {
-		return libcnb.Layer{}, fmt.Errorf("manifest does not contain Start-Class")
+	startClass, err := findStartOrMainClass(n.Manifest)
+	if err != nil {
+		return libcnb.Layer{}, fmt.Errorf("unable to find required manifest property\n%w", err)
 	}
 
 	arguments := n.Arguments


### PR DESCRIPTION
## Summary
Prior to this PR, it was required that you have a Start-Class entry in MANIFEST.MF. That is a Spring Boot convention though and not everyone has that entry.

To support non-Spring Boot apps better, this PR relaxes the requirement. If present, the Start-Class will be used. If not present, it will fall back to Main-Class which is a standard Java executable JAR convention. If neither are present, an error will occur.

Resolves #83.

## Use Cases
<!-- An explanation of the use cases your change enables -->

## Checklist
<!-- Please confirm the following -->
* [ ] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [ ] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [ ] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
