### PR TITLE
Implement RFC 0050: Rename Buildpack

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # `gcr.io/paketo-buildpacks/native-image`
 
-The Paketo Native Image Buildpack is a Cloud Native Buildpack that uses the [GraalVM Native Image builder][native-image] (`native-image`) to compile a standalone executable from an executable JAR.
+The Paketo Buildpack for Native Image is a Cloud Native Buildpack that uses the [GraalVM Native Image builder][native-image] (`native-image`) to compile a standalone executable from an executable JAR.
 
 Most users should not use this component buildpack directly and should instead use the [Paketo Java Native Image][bp/java-native-image], which provides the full set of buildpacks required to build a native image application.
 

--- a/buildpack.toml
+++ b/buildpack.toml
@@ -16,7 +16,7 @@ api = "0.7"
 
 [buildpack]
   id       = "paketo-buildpacks/native-image"
-  name     = "Paketo Native Image Buildpack"
+  name     = "Paketo Buildpack for Native Image"
   version  = "{{.version}}"
   homepage = "https://github.com/paketo-buildpacks/native-image"
   description = "A Cloud Native Buildpack that creates native images from Java applications"


### PR DESCRIPTION
Renames 'Paketo Native Image Buildpack' to 'Paketo Buildpack for Native Image'.

Implements RFC 0050, https://github.com/paketo-buildpacks/rfcs/issues/233, for this buildpack.

Signed-off-by: Daniel Mikusa <dmikusa@vmware.com>
