### PR TITLE
Removes module variable required in GraalVM 22.2

### DIFF
--- a/native/native_image.go
+++ b/native/native_image.go
@@ -75,13 +75,6 @@ func (n NativeImage) Contribute(layer libcnb.Layer) (libcnb.Layer, error) {
 		arguments = append([]string{"--no-fallback"}, arguments...)
 	}
 
-	moduleVar := "USE_NATIVE_IMAGE_JAVA_PLATFORM_MODULE_SYSTEM"
-	if _, set := os.LookupEnv(moduleVar); !set {
-		if err := os.Setenv(moduleVar, "false"); err != nil {
-			n.Logger.Bodyf("unable to set %s for GraalVM 22.2, if your build fails, you may need to set this manually at build time", moduleVar)
-		}
-	}
-
 	buf := &bytes.Buffer{}
 	if err := n.Executor.Execute(effect.Execution{
 		Command: "native-image",


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
The env var `USE_NATIVE_IMAGE_JAVA_PLATFORM_MODULE_SYSTEM` is no longer needed & is showing a build warning, this PR removes setting it at build time.

## Use Cases
Closes #273 

## Checklist
<!-- Please confirm the following -->
* [ ] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [ ] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [ ] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
