### PR TITLE
Also copy .so files when doing a native-image build

### DIFF
--- a/native/arguments.go
+++ b/native/arguments.go
@@ -18,7 +18,6 @@ package native
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"sort"
@@ -82,20 +81,20 @@ type UserFileArguments struct {
 // Configure returns the inputArgs plus the additional arguments provided via argfile, setting via the '@argfile' format
 func (u UserFileArguments) Configure(inputArgs []string) ([]string, string, error) {
 
-	rawArgs, err := ioutil.ReadFile(u.ArgumentsFile)
+	rawArgs, err := os.ReadFile(u.ArgumentsFile)
 	if err != nil {
 		return []string{}, "", fmt.Errorf("read arguments from %s\n%w", u.ArgumentsFile, err)
 	}
 
 	fileArgs := strings.Split(string(rawArgs), "\n")
-	if len(fileArgs) == 1{
+	if len(fileArgs) == 1 {
 		fileArgs = strings.Split(string(rawArgs), " ")
 	}
 
 	if containsArg("-jar", fileArgs) {
 		fileArgs = replaceJarArguments(fileArgs)
 		newArgList := strings.Join(fileArgs, " ")
-		if err = os.WriteFile(u.ArgumentsFile,[]byte(newArgList),0644); err != nil{
+		if err = os.WriteFile(u.ArgumentsFile, []byte(newArgList), 0644); err != nil {
 			return []string{}, "", fmt.Errorf("unable to write to arguments file %s\n%w", u.ArgumentsFile, err)
 		}
 	}
@@ -105,7 +104,6 @@ func (u UserFileArguments) Configure(inputArgs []string) ([]string, string, erro
 	return inputArgs, "", nil
 
 }
-
 
 // containsArg checks if needle is found in haystack
 //

--- a/native/arguments_test.go
+++ b/native/arguments_test.go
@@ -18,7 +18,6 @@ package native_test
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -40,13 +39,8 @@ func testArguments(t *testing.T, context spec.G, it spec.S) {
 	)
 
 	it.Before(func() {
-		var err error
-
-		ctx.Application.Path, err = ioutil.TempDir("", "native-image-application")
-		Expect(err).NotTo(HaveOccurred())
-
-		ctx.Layers.Path, err = ioutil.TempDir("", "native-image-layers")
-		Expect(err).NotTo(HaveOccurred())
+		ctx.Application.Path = t.TempDir()
+		ctx.Layers.Path = t.TempDir()
 	})
 
 	it.After(func() {
@@ -126,10 +120,10 @@ func testArguments(t *testing.T, context spec.G, it spec.S) {
 	context("user arguments from file", func() {
 		it.Before(func() {
 			Expect(os.MkdirAll(filepath.Join(ctx.Application.Path, "target"), 0755)).To(Succeed())
-			Expect(ioutil.WriteFile(filepath.Join(ctx.Application.Path, "target", "more-stuff.txt"), []byte("more stuff"), 0644)).To(Succeed())
-			Expect(ioutil.WriteFile(filepath.Join(ctx.Application.Path, "target", "more-stuff-quotes.txt"), []byte(`before -jar "more stuff.jar" after -other="my path"`), 0644)).To(Succeed())
-			Expect(ioutil.WriteFile(filepath.Join(ctx.Application.Path, "target", "more-stuff-class.txt"), []byte(`stuff -jar stuff.jar after`), 0644)).To(Succeed())
-			Expect(ioutil.WriteFile(filepath.Join(ctx.Application.Path, "target", "override.txt"), []byte(`one=output`), 0644)).To(Succeed())
+			Expect(os.WriteFile(filepath.Join(ctx.Application.Path, "target", "more-stuff.txt"), []byte("more stuff"), 0644)).To(Succeed())
+			Expect(os.WriteFile(filepath.Join(ctx.Application.Path, "target", "more-stuff-quotes.txt"), []byte(`before -jar "more stuff.jar" after -other="my path"`), 0644)).To(Succeed())
+			Expect(os.WriteFile(filepath.Join(ctx.Application.Path, "target", "more-stuff-class.txt"), []byte(`stuff -jar stuff.jar after`), 0644)).To(Succeed())
+			Expect(os.WriteFile(filepath.Join(ctx.Application.Path, "target", "override.txt"), []byte(`one=output`), 0644)).To(Succeed())
 		})
 
 		it("has none", func() {
@@ -146,7 +140,7 @@ func testArguments(t *testing.T, context spec.G, it spec.S) {
 			Expect(err).ToNot(HaveOccurred())
 			Expect(startClass).To(Equal(""))
 			Expect(args).To(HaveLen(4))
-			Expect(args).To(Equal([]string{"one", "two", "three", fmt.Sprintf("@%s",filepath.Join(ctx.Application.Path,"target/more-stuff.txt"))}))
+			Expect(args).To(Equal([]string{"one", "two", "three", fmt.Sprintf("@%s", filepath.Join(ctx.Application.Path, "target/more-stuff.txt"))}))
 		})
 
 		it("works with quotes in the file", func() {
@@ -158,7 +152,7 @@ func testArguments(t *testing.T, context spec.G, it spec.S) {
 			Expect(startClass).To(Equal(""))
 			Expect(args).To(HaveLen(4))
 			Expect(args).To(Equal([]string{"one", "two", "three", fmt.Sprintf("@%s", filepath.Join(ctx.Application.Path, "target/more-stuff-quotes.txt"))}))
-			bits, err := ioutil.ReadFile(filepath.Join(ctx.Application.Path, "target/more-stuff-quotes.txt"))
+			bits, err := os.ReadFile(filepath.Join(ctx.Application.Path, "target/more-stuff-quotes.txt"))
 			Expect(err).ToNot(HaveOccurred())
 			Expect(string(bits)).To(Equal("before after -other=\"my path\""))
 		})
@@ -170,9 +164,9 @@ func testArguments(t *testing.T, context spec.G, it spec.S) {
 			Expect(err).ToNot(HaveOccurred())
 			Expect(args).To(HaveLen(1))
 			Expect(args).To(Equal([]string{
-				fmt.Sprintf("@%s",filepath.Join(ctx.Application.Path, "target", "more-stuff-class.txt")),
+				fmt.Sprintf("@%s", filepath.Join(ctx.Application.Path, "target", "more-stuff-class.txt")),
 			}))
-			bits, err := ioutil.ReadFile(filepath.Join(ctx.Application.Path, "target/more-stuff-class.txt"))
+			bits, err := os.ReadFile(filepath.Join(ctx.Application.Path, "target/more-stuff-class.txt"))
 			Expect(err).ToNot(HaveOccurred())
 			Expect(string(bits)).To(Equal("after"))
 		})
@@ -254,9 +248,9 @@ func testArguments(t *testing.T, context spec.G, it spec.S) {
 	context("jar file", func() {
 		it.Before(func() {
 			Expect(os.MkdirAll(filepath.Join(ctx.Application.Path, "target"), 0755)).To(Succeed())
-			Expect(ioutil.WriteFile(filepath.Join(ctx.Application.Path, "target", "found.jar"), []byte{}, 0644)).To(Succeed())
-			Expect(ioutil.WriteFile(filepath.Join(ctx.Application.Path, "target", "a.two"), []byte{}, 0644)).To(Succeed())
-			Expect(ioutil.WriteFile(filepath.Join(ctx.Application.Path, "target", "b.two"), []byte{}, 0644)).To(Succeed())
+			Expect(os.WriteFile(filepath.Join(ctx.Application.Path, "target", "found.jar"), []byte{}, 0644)).To(Succeed())
+			Expect(os.WriteFile(filepath.Join(ctx.Application.Path, "target", "a.two"), []byte{}, 0644)).To(Succeed())
+			Expect(os.WriteFile(filepath.Join(ctx.Application.Path, "target", "b.two"), []byte{}, 0644)).To(Succeed())
 		})
 
 		it("adds arguments", func() {

--- a/native/build.go
+++ b/native/build.go
@@ -19,9 +19,10 @@ package native
 import (
 	"errors"
 	"fmt"
-	"github.com/paketo-buildpacks/libpak/sherpa"
 	"os"
 	"path/filepath"
+
+	"github.com/paketo-buildpacks/libpak/sherpa"
 
 	"github.com/paketo-buildpacks/libpak/effect"
 	"github.com/paketo-buildpacks/libpak/sbom"


### PR DESCRIPTION
## Summary

Some applications, when native-image runs, will also generate shared libraries which are required to run the application. These libraries get put next to the generated binary file. This change modifies the buildpack to copy these shared libraries after it copies the binary to the application directory.

In a nutshell, native-image runs, writes binary and shared libs to a cached layer. We then copy files from the cached layer to the application directory (i.e. /workspace) which results in them being available in the application image.

Resolves #308 

## Use Cases

Support native-image builds that require additional JNI libraries, like when using AWT.

## Checklist
<!-- Please confirm the following -->
* [ ] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [ ] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [ ] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
